### PR TITLE
Auto repatch on file change

### DIFF
--- a/Core/ModLoader.cs
+++ b/Core/ModLoader.cs
@@ -326,7 +326,7 @@ namespace ScrollsModLoader {
 			}
 
 			try {
-				if (File.GetLastWriteTime(modLoaderPath+"Assembly-CSharp.dll") < File.GetLastWriteTime(filepath)) {
+				if (File.GetLastWriteTime(Platform.getGlobalScrollsInstallPath ()+"Assembly-CSharp.dll") < File.GetLastWriteTime(filepath)) {
 					Console.WriteLine ("New Mod Version - Repatching!!!");
 					queueRepatch ();
 				}


### PR DESCRIPTION
Detects if a `mod.dll` file is newer than the `Assembly-CSharp.dll` and will repatch automatically.

To be on the safe side there should be a way to restrict it to not do it twice...
